### PR TITLE
Adding FAISS support

### DIFF
--- a/src/environment.yml
+++ b/src/environment.yml
@@ -89,6 +89,7 @@ dependencies:
       - bert-serving-server==1.10.0
       - cachetools==5.3.0
       - en-core-web-sm==3.3.0
+      - faiss-cpu===1.7.4
       - flatbuffers==23.3.3
       - gast==0.4.0
       - google-auth==2.17.3


### PR DESCRIPTION
Adding FAISS support.

This is review only PR.
There is no support for vector store metadata filtering. We need to figure out way as it searches on all data.
But FAISS search is fast compare to previous implementation, hence do we need to classify and filter question?

Lets discuss regarding above issues.

I have tested it on 'tfidf' and 'openai' embeddings, it is also working on Bert at my local setup.

Thanks,
Pritam
